### PR TITLE
fix: use loading skeleton instead of loading text

### DIFF
--- a/src/components/LoadingIndicator.tsx
+++ b/src/components/LoadingIndicator.tsx
@@ -1,7 +1,0 @@
-export const LoadingIndicator = () => {
-  return (
-    <div className="text-center">
-      <span className="text-black mt-2 text-xl">Generating...</span>
-    </div>
-  );
-};

--- a/src/components/skeleton.tsx
+++ b/src/components/skeleton.tsx
@@ -1,0 +1,7 @@
+import { cn } from "@/lib/utils";
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return <div data-slot="skeleton" className={cn("bg-gray-100 animate-pulse rounded-md", className)} {...props} />;
+}
+
+export { Skeleton };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,12 +7,12 @@ import {
 } from "@/lib/constants";
 import { FiX, FiRepeat, FiTrash, FiDelete, FiEdit, FiSave, FiCornerDownRight } from "react-icons/fi";
 import { NoSupportedSizeScreenMessage } from "@/components/NoSupportedSizeScreenMessage";
-import { LoadingIndicator } from "@/components/LoadingIndicator";
 import { CharacterLimit } from "@/components/CharacterLimit";
 import { countTagsLength } from "@/lib/count-tags-length";
 import { ToastContainer, toast } from "react-toastify";
 import { MainWrapper } from "@/components/MainWrapper";
 import { Container } from "@/components/Container";
+import { Skeleton } from "@/components/skeleton";
 import { Button } from "../components/Button";
 import { Footer } from "@/components/Footer";
 import { Response } from "@/types/response";
@@ -551,8 +551,14 @@ export default function Home() {
           </div>
         </form>
         {loading ? (
-          <div className="mt-28 flex justify-center items-center">
-            <LoadingIndicator />
+          <div className="mt-6 flex justify-center items-center">
+            <div className="border w-full p-4 rounded-lg">
+              <div className="flex flex-wrap gap-4 my-4 mt-6">
+                {[340, 240, 140, 340, 220, 400, 240, 140, 540, 340, 300, 240, 340, 180, 400].map((skeleton, index) => (
+                  <Skeleton key={index} className={`h-[42px] rounded-lg w-[${skeleton}px] animate-pulse`} />
+                ))}
+              </div>
+            </div>
           </div>
         ) : (
           <div className="flex flex-col">


### PR DESCRIPTION
This pull request replaces the previous loading indicator with a new skeleton loading UI to improve the user experience while content is being generated. The changes introduce a reusable `Skeleton` component and update the loading state in the main page to display multiple skeleton placeholders instead of a single message.

**Loading indicator replacement and UI improvements:**

* Removed the old `LoadingIndicator` component from `src/components/LoadingIndicator.tsx` and its usage in `src/pages/index.tsx`. [[1]](diffhunk://#diff-83c12448ccfac98ca13930aa4fed2b01ceb54b1e0b0d24f3db0e4b5eff87dbacL1-L7) [[2]](diffhunk://#diff-18e0d4553c97cfc420e938ccafb4e3a688e782fa4512ba4ceae3e2a6f24c1987L10-R15)
* Added a new `Skeleton` component in `src/components/skeleton.tsx` for displaying animated skeleton placeholders.
* Updated the loading state in `src/pages/index.tsx` to render a grid of skeletons using the new `Skeleton` component, providing a more visually appealing loading experience.