### PR TITLE
feat: make it development feature accessible with the debug query

### DIFF
--- a/src/components/DevelopmentNav.tsx
+++ b/src/components/DevelopmentNav.tsx
@@ -1,7 +1,11 @@
+import { useRouter } from "next/router";
+
 export const DevelopmentNav = () => {
+  const router = useRouter();
+
   return (
     <>
-      {process.env.NODE_ENV === "development" ? (
+      {process.env.NODE_ENV === "development" || router.query.debug === "true" ? (
         <div className="flex fixed items-center font-light justify-center top-0 z-50 w-full bg-green-600">
           <span className="text-white text-sm">
             {" "}

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -3,9 +3,12 @@ import { NavYouTubeLogo } from "./NavYouTubeLogo";
 import { useEffect, useState } from "react";
 
 // Next.js
+import { useRouter } from "next/router";
 import Link from "next/link";
 
 export const Nav = () => {
+  const router = useRouter();
+
   const [scrolled, setScrolled] = useState(false);
 
   useEffect(() => {
@@ -20,7 +23,7 @@ export const Nav = () => {
   return (
     <nav
       className={`lg:flex items-center fixed justify-between h-20 w-full px-20 bg-white hidden ${
-        process.env.NODE_ENV === "development" ? "top-5" : "top-0"
+        process.env.NODE_ENV === "development" || router.query.debug === "true" ? "top-5" : "top-0"
       } z-50 transition-shadow duration-500 ${scrolled ? "fixed shadow-md h-20" : "fixed shadow-none"}`}
     >
       <Link href="/" className="flex items-center">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -32,10 +32,15 @@ import { GENRE } from "@/lib/genre";
 import { seo } from "@/lib/seo/seo";
 
 // Next.js
+import { useRouter } from "next/router";
 import Link from "next/link";
 
 export default function Home() {
-  const [clearAfterResponse, setClearAfterResponse] = useState(process.env.NODE_ENV === "development" ? false : true);
+  const router = useRouter();
+
+  const [clearAfterResponse, setClearAfterResponse] = useState(
+    process.env.NODE_ENV === "development" || router.query.debug === "true" ? false : true
+  );
   const [showCustomFormatStringTemplateSection, setShowCustomFormatStringTemplateSection] = useState(false);
   const [showRecommendedTagsToBeDeleteSection, setShowRecommendedTagsToBeDeleteSection] = useState(false);
   const [usedGenerateExampleResponse, setUsedGenerateExampleResponse] = useState(false);
@@ -109,7 +114,7 @@ export default function Home() {
         : localStorageCustomFormat.length
         ? `${artist.trim().split("/")[0]}/${localStorageCustomFormat}`
         : artist.trim(),
-      log: process.env.NODE_ENV === "development" ? `${enableLogging}` : "true",
+      log: process.env.NODE_ENV === "development" || router.query.debug === "true" ? `${enableLogging}` : "true",
       features: features.trim().length ? features.trim() : "none",
       channel: channel.trim().length ? channel.trim() : "none",
       title: title.trim().length ? title.trim() : "none",
@@ -556,7 +561,7 @@ export default function Home() {
                 </Button>
               </div>
             </div>
-            {process.env.NODE_ENV === "development" ? (
+            {process.env.NODE_ENV === "development" || router.query.debug === "true" ? (
               <div className="flex flex-col w-full items-center mt-8 font-light">
                 <div className="flex items-center justify-between w-full">
                   <p>


### PR DESCRIPTION
This pull request introduces a "debug mode" that can be activated by setting the `debug` query parameter to `"true"` in the URL. When enabled, it allows development-only UI elements and behaviors to be accessible even in non-development environments. The most important changes involve updating conditional logic throughout the codebase to check for either development mode or the presence of the debug flag.

**Debug Mode Activation and Conditional UI Changes:**

* Updated conditional checks in `DevelopmentNav.tsx`, `Nav.tsx`, and `index.tsx` to show development-only UI elements when either `process.env.NODE_ENV === "development"` or `router.query.debug === "true"` is true, allowing debug mode activation via URL. [[1]](diffhunk://#diff-915e432a83bb7713dce2106ac018254c9bd9c5959fd922c47c8d9dca2197d505R1-R8) [[2]](diffhunk://#diff-7f2ef60bbec771e3e2a3e1e7162d91e481d7724cd76ea86a82a0b4ad45c3baefL23-R26) [[3]](diffhunk://#diff-18e0d4553c97cfc420e938ccafb4e3a688e782fa4512ba4ceae3e2a6f24c1987L559-R564)

**Debug Mode Propagation and State Initialization:**

* Modified state initialization and request parameter logic in `index.tsx` so that debug mode also affects the default value of `clearAfterResponse` and the value of the `log` parameter, making debug-specific behaviors available outside of development environments. [[1]](diffhunk://#diff-18e0d4553c97cfc420e938ccafb4e3a688e782fa4512ba4ceae3e2a6f24c1987R35-R43) [[2]](diffhunk://#diff-18e0d4553c97cfc420e938ccafb4e3a688e782fa4512ba4ceae3e2a6f24c1987L112-R117)

**Router Usage for Debug Flag:**

* Added usage of Next.js's `useRouter` hook in components (`DevelopmentNav.tsx`, `Nav.tsx`, and `index.tsx`) to access the `debug` query parameter for conditional rendering and logic. [[1]](diffhunk://#diff-915e432a83bb7713dce2106ac018254c9bd9c5959fd922c47c8d9dca2197d505R1-R8) [[2]](diffhunk://#diff-7f2ef60bbec771e3e2a3e1e7162d91e481d7724cd76ea86a82a0b4ad45c3baefR6-R11) [[3]](diffhunk://#diff-18e0d4553c97cfc420e938ccafb4e3a688e782fa4512ba4ceae3e2a6f24c1987R35-R43)