### PR TITLE
feat: finish testo tags + complete delete functionality

### DIFF
--- a/src/lib/helpers/tags/remove/testo-tags-remove.ts
+++ b/src/lib/helpers/tags/remove/testo-tags-remove.ts
@@ -69,6 +69,77 @@ export const testoTagsRemove = (
         ];
 
         return patterns.map((pattern) => pattern.trim().toLowerCase());
+      } else if (feats.length === 2) {
+        const patterns: string[] = [
+          `testo ${artist}`,
+          `${secondFeature} ${title} testo`,
+          `testo ${title} ${artist}`,
+          `${firstFeature} ${title} testo`,
+          `${artist} - ${title} testo`,
+          `${artist} ${firstFeature} ${title}`,
+          `${artist} - ${title}`,
+          `testo ${title}`,
+          `${artist} ${title} testo`,
+          `${secondFeature} ${title}`,
+          `${artist} ${secondFeature}`,
+          `${title} ${secondFeature}`,
+          `${title} testo ${artist}`,
+          `${artist} testo ${title}`,
+          `${title} ${artist}`,
+          `${artist} ${title}`,
+          `${artist} testo`,
+          `${title} testo`,
+          `${artist}`,
+          `${title}`,
+          `testo`,
+          `${firstFeature} ${title}`,
+          `${title} ${firstFeature}`,
+          `${artist} ${firstFeature}`,
+          `${firstFeature} ${artist}`,
+          `${secondFeature}`,
+          `${firstFeature}`,
+        ];
+
+        return patterns.map((pattern) => pattern.trim().toLowerCase());
+      } else if (feats.length === 3) {
+        const thirdFeature = feats[2];
+
+        const patterns: string[] = [
+          `testo ${artist}`,
+          `${secondFeature} ${title} testo`,
+          `testo ${title} ${artist}`,
+          `${firstFeature} ${title} testo`,
+          `${artist} - ${title} testo`,
+          `${artist} ${firstFeature} ${title}`,
+          `${thirdFeature} ${title} testo`,
+          `${artist} - ${title}`,
+          `testo ${title}`,
+          `${artist} ${title} testo`,
+          `${secondFeature} ${title}`,
+          `${artist} ${secondFeature}`,
+          `${title} ${secondFeature}`,
+          `${thirdFeature} ${title}`,
+          `${artist} ${thirdFeature}`,
+          `${title} ${thirdFeature}`,
+          `${title} testo ${artist}`,
+          `${artist} testo ${title}`,
+          `${title} ${artist}`,
+          `${artist} ${title}`,
+          `${artist} testo`,
+          `${title} testo`,
+          `${artist}`,
+          `${title}`,
+          `testo`,
+          `${firstFeature} ${title}`,
+          `${title} ${firstFeature}`,
+          `${artist} ${firstFeature}`,
+          `${firstFeature} ${artist}`,
+          `${thirdFeature}`,
+          `${secondFeature}`,
+          `${firstFeature}`,
+        ];
+
+        return patterns.map((pattern) => pattern.trim().toLowerCase());
       }
 
       return [];

--- a/src/lib/helpers/tags/testo-lyrics.ts
+++ b/src/lib/helpers/tags/testo-lyrics.ts
@@ -5,15 +5,25 @@ export const testoTags = (artist: string, title: string, features: string, tikto
   // Features
   let feats = features.split(",").map((feat) => feat.trim());
 
-  // First feat
-  const firstFeat = feats[0];
+  // First feature
+  const firstFeature = feats[0];
 
   // Features
   if (features !== "none" && (tiktok === "false" || tiktok === "" || tiktok !== "true")) {
-    tags += `,${firstFeat} ${title},${artist} ${firstFeat} ${title},${firstFeat} ${title} testo,${title} ${firstFeat},${artist} ${firstFeat},${firstFeat} ${artist},${firstFeat}`;
-    if (features.length >= 2) {
-      // Second feat
-      const secondFeat = feats[1];
+    tags += `,${firstFeature} ${title},${artist} ${firstFeature} ${title},${firstFeature} ${title} testo,${title} ${firstFeature},${artist} ${firstFeature},${firstFeature} ${artist},${firstFeature}`;
+
+    // Second feature
+    if (feats.length === 2) {
+      const secondFeature = feats[1];
+
+      tags += `,${secondFeature},${secondFeature} ${title} testo,${secondFeature} ${title},${artist} ${secondFeature},${title} ${secondFeature}`;
+    }
+
+    // Third feature
+    if (feats.length === 3) {
+      const thirdFeature = feats[2];
+
+      tags += `,${thirdFeature},${thirdFeature} ${title} testo,${thirdFeature} ${title},${artist} ${thirdFeature},${title} ${thirdFeature}`;
     }
   }
 


### PR DESCRIPTION
This pull request expands and improves the logic for generating and removing "testo" tags when songs have multiple featured artists. The main focus is to handle cases where there are two or three features, ensuring that all relevant tag patterns are generated and removed consistently.

Enhancements to tag generation and removal for multiple features:

**Tag generation improvements (`testoTags` in `testo-lyrics.ts`):**
- Expanded logic to generate additional tag combinations when a song has two or three featured artists, including tags for each feature and their combinations with the artist and title.
- Standardized variable naming from `firstFeat`/`secondFeat` to `firstFeature`/`secondFeature` for clarity and consistency.

**Tag removal improvements (`testoTagsRemove` in `testo-tags-remove.ts`):**
- Added comprehensive pattern lists for removing tags when there are two or three featured artists, covering all relevant combinations of artist, title, and features.
- Ensured that all generated tag patterns are normalized (trimmed and lowercased) before use, improving reliability.