### PR TITLE
feat: finish up nightcore sped up tags remove

### DIFF
--- a/src/lib/helpers/tags/remove-tags.ts
+++ b/src/lib/helpers/tags/remove-tags.ts
@@ -1,3 +1,4 @@
+import { nightcoreSpedUpTagsRemove } from "./remove/nightcore-sped-up-tags-remove";
 import { slowedReverbTagsRemove } from "./remove/slowed-reverb-tags-remove";
 import { bassBoostedTagsRemove } from "./remove/bass-boosted-tags-remove";
 import { lyricsTagsRemove } from "./remove/lyrics-tags-remove";
@@ -26,6 +27,11 @@ export const removeTags = (
   // Bass Boosted
   if (format === FORMAT.bassboosted) {
     return bassBoostedTagsRemove(title, artist, features, tiktok, tags);
+  }
+
+  // Nightcore / Sped Up
+  if (format === FORMAT.nightcore) {
+    return nightcoreSpedUpTagsRemove(title, artist, features, tiktok, tags);
   }
 
   // Letra

--- a/src/lib/helpers/tags/remove/lyrics-tags-remove.ts
+++ b/src/lib/helpers/tags/remove/lyrics-tags-remove.ts
@@ -67,7 +67,7 @@ export const lyricsTagsRemove = (
 
         return patterns.map((pattern) => pattern.trim().toLowerCase());
       } else if (feats.length === 2) {
-        const patterns = [
+        const patterns: string[] = [
           `lyrics ${title} ${artist}`,
           `lyrics ${artist} ${title}`,
           `lyrics ${firstFeature} ${title}`,

--- a/src/lib/helpers/tags/remove/nightcore-sped-up-tags-remove.ts
+++ b/src/lib/helpers/tags/remove/nightcore-sped-up-tags-remove.ts
@@ -1,0 +1,122 @@
+import { tagsDeletionAlgorithm } from "./helpers/tags-deletion-algorithm";
+
+export const nightcoreSpedUpTagsRemove = (
+  title: string,
+  artist: string,
+  features: string,
+  tiktok: string,
+  tags: string
+): string => {
+  if (features === "none") {
+    const generateConcreteLeastEfficientTags = (artist: string, title: string) => {
+      const patterns: string[] = [
+        `${title} sped up ${artist}`,
+        `${title} sped up`,
+        `${artist} ${title}`,
+        `${title} nightcore`,
+        `${artist} ${title} sped up`,
+        `${artist} nightcore`,
+        `${artist} sped up`,
+        `${artist}`,
+        `${title}`,
+        `nightcore`,
+      ];
+
+      return patterns.map((pattern) => pattern.trim().toLowerCase());
+    };
+
+    const concreteLeastEfficientTags = generateConcreteLeastEfficientTags(artist, title);
+
+    return tagsDeletionAlgorithm(concreteLeastEfficientTags, tags.toLowerCase());
+  }
+
+  if (features !== "none") {
+    const generateConcreteLeastEfficientTags = (artist: string, title: string) => {
+      let feats = features.split(",").map((feat) => feat.trim());
+
+      const secondFeature = feats[1];
+      const firstFeature = feats[0];
+
+      if (feats.length === 1) {
+        const patterns: string[] = [
+          `title ${firstFeature}`,
+          `${firstFeature} ${title}`,
+          `${artist} ${firstFeature}`,
+          `${title} sped up ${artist}`,
+          `${title} sped up`,
+          `${artist} ${title}`,
+          `${title} nightcore`,
+          `${artist} ${title} sped up`,
+          `${artist} nightcore`,
+          `${artist} sped up`,
+          `${firstFeature}`,
+          `${artist}`,
+          `${title}`,
+          `nightcore`,
+        ];
+
+        return patterns.map((pattern) => pattern.trim().toLowerCase());
+      } else if (feats.length === 2) {
+        const patterns: string[] = [
+          `title ${secondFeature}`,
+          `${secondFeature} ${title}`,
+          `${artist} ${secondFeature}`,
+          `title ${firstFeature}`,
+          `${firstFeature} ${title}`,
+          `${artist} ${firstFeature}`,
+          `${title} sped up ${artist}`,
+          `${title} sped up`,
+          `${artist} ${title}`,
+          `${title} nightcore`,
+          `${artist} ${title} sped up`,
+          `${artist} nightcore`,
+          `${artist} sped up`,
+          `${secondFeature}`,
+          `${firstFeature}`,
+          `${artist}`,
+          `${title}`,
+          `nightcore`,
+        ];
+
+        return patterns.map((pattern) => pattern.trim().toLowerCase());
+      } else if (feats.length === 3) {
+        const thirdFeature = feats[2];
+
+        const patterns: string[] = [
+          `title ${thirdFeature}`,
+          `${thirdFeature} ${title}`,
+          `${artist} ${thirdFeature}`,
+          `title ${secondFeature}`,
+          `${secondFeature} ${title}`,
+          `${artist} ${secondFeature}`,
+          `title ${firstFeature}`,
+          `${firstFeature} ${title}`,
+          `${artist} ${firstFeature}`,
+          `${title} sped up ${artist}`,
+          `${title} sped up`,
+          `${artist} ${title}`,
+          `${title} nightcore`,
+          `${artist} ${title} sped up`,
+          `${artist} nightcore`,
+          `${artist} sped up`,
+          `${thirdFeature}`,
+          `${secondFeature}`,
+          `${firstFeature}`,
+          `${artist}`,
+          `${title}`,
+          `nightcore`,
+        ];
+
+        return patterns.map((pattern) => pattern.trim().toLowerCase());
+      }
+
+      return [];
+    };
+
+    const concreteLeastEfficientTags = generateConcreteLeastEfficientTags(artist, title);
+
+    return tagsDeletionAlgorithm(concreteLeastEfficientTags, tags.toLowerCase());
+  }
+
+  return "";
+};


### PR DESCRIPTION
This pull request adds support for removing "nightcore" and "sped up" tags from track metadata, improving the tag-cleaning functionality for these specific formats. The main change is the introduction of a new tag removal function for nightcore/sped up tracks, which is now integrated into the tag removal pipeline. Additionally, there are minor type and import improvements.

**Nightcore/Sped Up Tag Removal:**

* Added a new `nightcoreSpedUpTagsRemove` function in `nightcore-sped-up-tags-remove.ts` to generate and remove common "nightcore" and "sped up" tag patterns, supporting tracks with or without featured artists.
* Integrated the new `nightcoreSpedUpTagsRemove` function into the main `removeTags` pipeline in `remove-tags.ts`, so it is used when the track format is nightcore/sped up.
* Imported `nightcoreSpedUpTagsRemove` in `remove-tags.ts` to enable its usage.

**Other improvements:**

* Improved type annotation for the `patterns` array in `lyricsTagsRemove` for better type safety.