### PR TITLE
feat: complete the lyrics string format template page

### DIFF
--- a/src/lib/generate-random-id.ts
+++ b/src/lib/generate-random-id.ts
@@ -1,0 +1,3 @@
+export const generateRandomId = (): number => {
+  return Date.now() + Math.random();
+};

--- a/src/lib/template-string-format-list.ts
+++ b/src/lib/template-string-format-list.ts
@@ -1,0 +1,54 @@
+import { TemplateStringFormatList } from "@/types/template-string-format-list";
+import { generateRandomId } from "./generate-random-id";
+
+export const TEMPLATE_STRING_FORMAT_LIST: TemplateStringFormatList[] = [
+  {
+    id: generateRandomId(),
+    format: "Lyrics",
+    filter: "lyrics",
+    formats: [
+      {
+        id: generateRandomId(),
+        constraint: "(lyrics)::[default]",
+        template:
+          "{artist} {title},{artist} {title} lyrics,{title} lyrics,{title} {artist} lyrics,lyrics {title},{artist} lyrics {title},{title} lyric video,{artist} lyrics,lyrics {artist},{title},{artist},{title} {artist},lyrics {title} {artist},lyrics {artist} {title},lyrics",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(lyrics)::[feature-1]",
+        template:
+          "{firstFeature},{firstFeature} {title} lyrics,lyrics {firstFeature} {title},{firstFeature} lyrics,{firstFeature} {title},{artist} {firstFeature},{title} {firstFeature}",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(lyrics)::includes[default]&&[feature-1]",
+        template:
+          "{artist} {title},{artist} {title} lyrics,{title} lyrics,{title} {artist} lyrics,lyrics {title},{artist} lyrics {title},{title} lyric video,{artist} lyrics,lyrics {artist},{title},{artist},{title} {artist},lyrics {title} {artist},lyrics {artist} {title},lyrics,{firstFeature},{firstFeature} {title} lyrics,lyrics {firstFeature} {title},{firstFeature} lyrics,{firstFeature} {title},{artist} {firstFeature},{title} {firstFeature}",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(lyrics)::[feature-2]",
+        template:
+          "{secondFeature},{secondFeature} {title} lyrics,{secondFeature} {title},{artist} {secondFeature},{title} {secondFeature}",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(lyrics)::includes[default]&&[feature-1]&&[feature-2]",
+        template:
+          "{artist} {title},{artist} {title} lyrics,{title} lyrics,{title} {artist} lyrics,lyrics {title},{artist} lyrics {title},{title} lyric video,{artist} lyrics,lyrics {artist},{title},{artist},{title} {artist},lyrics {title} {artist},lyrics {artist} {title},lyrics,{firstFeature},{firstFeature} {title} lyrics,lyrics {firstFeature} {title},{firstFeature} lyrics,{firstFeature} {title},{artist} {firstFeature},{title} {firstFeature},{secondFeature},{secondFeature} {title} lyrics,{secondFeature} {title},{artist} {secondFeature},{title} {secondFeature}",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(lyrics)::[feature-3]",
+        template:
+          "{thirdFeature},{thirdFeature} {title} lyrics,{thirdFeature} {title},{artist} {thirdFeature},{title} {thirdFeature}",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(lyrics)::includes[default]&&[feature-1]&&[feature-2]&&[feature-3]",
+        template:
+          "{artist} {title},{artist} {title} lyrics,{title} lyrics,{title} {artist} lyrics,lyrics {title},{artist} lyrics {title},{title} lyric video,{artist} lyrics,lyrics {artist},{title},{artist},{title} {artist},lyrics {title} {artist},lyrics {artist} {title},lyrics,{firstFeature},{firstFeature} {title} lyrics,lyrics {firstFeature} {title},{firstFeature} lyrics,{firstFeature} {title},{artist} {firstFeature},{title} {firstFeature},{secondFeature},{secondFeature} {title} lyrics,{secondFeature} {title},{artist} {secondFeature},{title} {secondFeature},{thirdFeature},{thirdFeature} {title} lyrics,{thirdFeature} {title},{artist} {thirdFeature},{title} {thirdFeature}",
+      },
+    ],
+  },
+];

--- a/src/pages/format/[slug].tsx
+++ b/src/pages/format/[slug].tsx
@@ -1,24 +1,42 @@
 import { NoSupportedSizeScreenMessage } from "@/components/NoSupportedSizeScreenMessage";
+import { TEMPLATE_STRING_FORMAT_LIST } from "@/lib/template-string-format-list";
 import { returnComputedFormatText } from "@/lib/return-computed-format-text";
 import { DevelopmentNav } from "@/components/DevelopmentNav";
 import { MainWrapper } from "@/components/MainWrapper";
 import { Container } from "@/components/Container";
+import { Footer } from "@/components/Footer";
 import { GetServerSideProps } from "next";
 import { Nav } from "@/components/Nav";
 import { Seo } from "@/components/Seo";
 import { NextPage } from "next";
 
 const Slug: NextPage<{ slug: string }> = ({ slug }) => {
-  const format = returnComputedFormatText(slug);
+  const computedFormatTextLyricsTemplateTitle = returnComputedFormatText(slug);
+  const templates = TEMPLATE_STRING_FORMAT_LIST.find((f) => f.filter == slug);
 
   return (
     <Container>
-      <Seo seoTitle={`${format} Format | Lyrics Tags Generator`} seoDescription="" />
+      <Seo seoTitle={`${computedFormatTextLyricsTemplateTitle} Format | Lyrics Tags Generator`} seoDescription="" />
       <NoSupportedSizeScreenMessage />
       <DevelopmentNav />
       <Nav />
       <MainWrapper>
-        <h1 className="text-4xl font-black tracking-tight mt-8">{format.length ? format : "None"}</h1>
+        <h1 className="text-4xl font-black tracking-tight mt-8">
+          {computedFormatTextLyricsTemplateTitle.length ? computedFormatTextLyricsTemplateTitle : "None"}
+        </h1>
+        <div className="flex flex-col mt-8 mb-auto">
+          {templates
+            ? templates.formats.map((format) => (
+                <div className="mb-8">
+                  <h1 className="text-3xl mb-4 tracking-tight font-light">{format.constraint}</h1>
+                  <div className="bg-gray-100 p-3 rounded-lg">
+                    <p className="text-xl whitespace-nowrap overflow-x-auto text-gray-800"> {format.template}</p>
+                  </div>
+                </div>
+              ))
+            : null}
+        </div>
+        <Footer />
       </MainWrapper>
     </Container>
   );

--- a/src/types/template-string-format-list.ts
+++ b/src/types/template-string-format-list.ts
@@ -1,0 +1,12 @@
+export interface TemplateStringFormatList {
+  formats: Format[];
+  format: string;
+  filter: string;
+  id: number;
+}
+
+export interface Format {
+  constraint: string;
+  template: string;
+  id: number;
+}


### PR DESCRIPTION
This pull request introduces a new template system for formatting lyrics tag generation and integrates it into the format page. The main changes include the creation of a reusable template list with constraints, the addition of random ID generation for template items, and updates to the page logic to display these templates dynamically.

**Template System Implementation**

* Added a new `TEMPLATE_STRING_FORMAT_LIST` constant in `template-string-format-list.ts` that defines a list of lyrics format templates, each with constraints and template strings, and assigns them unique IDs using a new random ID generator. [[1]](diffhunk://#diff-ca2bcb6339db9dfb3ddfe3fbce826a02f78261f455a67cac6ad641081014bfe4R1-R54) [[2]](diffhunk://#diff-1189dc9438b2c7c01c08307eda0f6d7b68d6616c714320cec816d01cba8876d1R1-R3)
* Defined new TypeScript interfaces `TemplateStringFormatList` and `Format` to provide strong typing for the lyrics template system.

**Page Integration and Rendering**

* Updated the `[slug].tsx` format page to use the new template list: it now finds the relevant template group by slug, renders all associated constraints and template strings, and displays them in a styled format. The page also now uses the new computed format text variable for improved clarity. ([src/pages/format/[slug].tsxR2-R39](diffhunk://#diff-c1e2d53f1ffbc7d418d23a17dbd208bf7520de54e2a0691f3e5b4f1fb7a48a6cR2-R39))
* Added the `Footer` component to the format page for improved layout and navigation. ([src/pages/format/[slug].tsxR2-R39](diffhunk://#diff-c1e2d53f1ffbc7d418d23a17dbd208bf7520de54e2a0691f3e5b4f1fb7a48a6cR2-R39))