### PR TITLE
feat: complete bass boosted string format template page

### DIFF
--- a/src/lib/template-string-format-list.ts
+++ b/src/lib/template-string-format-list.ts
@@ -55,4 +55,54 @@ export const TEMPLATE_STRING_FORMAT_LIST: TemplateStringFormatList[] = [
       },
     ],
   },
+  {
+    id: generateRandomId(),
+    filter: "bassboosted",
+    formats: [
+      {
+        id: generateRandomId(),
+        constraint: "(bassboosted)::[default]",
+        template:
+          "{artist},{title},{title} bass boosted,{title} bass boosted {artist},{title} {artist},{title} {artist} bass boosted,{artist} {title} bass boosted,{artist} {title},{artist} - {title},{artist} - {title} bass boosted,{title} {artist} bass boost,{artist} bass boosted,{title} bass boost,bass boost,bass boosted,bass boosted car playlist,bass boost car playlist",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(bassboosted)::[feature-1]",
+        template: "{firstFeature},{firstFeature} {title} bass boosted",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(bassboosted)::includes[default]&&[feature-1]",
+        template:
+          "{artist},{title},{title} bass boosted,{title} bass boosted {artist},{title} {artist},{title} {artist} bass boosted,{artist} {title} bass boosted,{artist} {title},{artist} - {title},{artist} - {title} bass boosted,{title} {artist} bass boost,{artist} bass boosted,{title} bass boost,bass boost,bass boosted,bass boosted car playlist,bass boost car playlist,{firstFeature},{firstFeature} {title} bass boosted",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(bassboosted)::[feature-2]",
+        template: "{secondFeature},{secondFeature} {title} bass boosted",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(bassboosted)::includes[default]&&[feature-1]&&[feature-2]",
+        template:
+          "{artist},{title},{title} bass boosted,{title} bass boosted {artist},{title} {artist},{title} {artist} bass boosted,{artist} {title} bass boosted,{artist} {title},{artist} - {title},{artist} - {title} bass boosted,{title} {artist} bass boost,{artist} bass boosted,{title} bass boost,bass boost,bass boosted,bass boosted car playlist,bass boost car playlist,{firstFeature},{firstFeature} {title} bass boosted,{secondFeature},{secondFeature} {title} bass boosted",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(bassboosted)::[feature-3]",
+        template: "{thirdFeature},{thirdFeature} {title} bass boosted",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(bassboosted)::includes[default]&&[feature-1]&&[feature-2]&&[feature-3]",
+        template:
+          "{artist},{title},{title} bass boosted,{title} bass boosted {artist},{title} {artist},{title} {artist} bass boosted,{artist} {title} bass boosted,{artist} {title},{artist} - {title},{artist} - {title} bass boosted,{title} {artist} bass boost,{artist} bass boosted,{title} bass boost,bass boost,bass boosted,bass boosted car playlist,bass boost car playlist,{firstFeature},{firstFeature} {title} bass boosted,{secondFeature},{secondFeature} {title} bass boosted,{thirdFeature},{thirdFeature} {title} bass boosted",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(bassboosted)::[@tiktok=true@]",
+        template: "tiktok,{title} tiktok,trending tiktok,tiktok songs",
+      },
+    ],
+  },
 ];

--- a/src/pages/format/[slug].tsx
+++ b/src/pages/format/[slug].tsx
@@ -30,7 +30,7 @@ const Slug: NextPage<{ slug: string }> = ({ slug }) => {
           {templates
             ? templates.formats.map((format) => (
                 <div className="mb-8">
-                  <h1 className="text-3xl mb-4 tracking-tight font-light">{format.constraint}</h1>
+                  <h1 className="text-2xl mb-4 tracking-tight">{format.constraint}</h1>
                   <div className="bg-gray-100 p-3 rounded-lg">
                     <p className="text-xl whitespace-nowrap overflow-x-auto text-gray-800"> {format.template}</p>
                   </div>


### PR DESCRIPTION
This pull request adds support for "bassboosted" template string formats and makes a minor UI adjustment to the format constraint heading size on the format details page. The main change is the introduction of a comprehensive set of "bassboosted" templates with various constraints and feature combinations.

**Template format additions:**

* Added a new entry for "bassboosted" in the `TEMPLATE_STRING_FORMAT_LIST`, including templates for default, feature-specific, combined features, and TikTok-related constraints.

**UI adjustments:**

* Changed the format constraint heading size from `text-3xl` to `text-2xl` on the format details page in `src/pages/format/[slug].tsx` to better fit the UI. ([src/pages/format/[slug].tsxL33-R33](diffhunk://#diff-c1e2d53f1ffbc7d418d23a17dbd208bf7520de54e2a0691f3e5b4f1fb7a48a6cL33-R33))