### PR TITLE
feat: complete nightcore string format template page

### DIFF
--- a/src/lib/template-string-format-list.ts
+++ b/src/lib/template-string-format-list.ts
@@ -105,4 +105,54 @@ export const TEMPLATE_STRING_FORMAT_LIST: TemplateStringFormatList[] = [
       },
     ],
   },
+  {
+    id: generateRandomId(),
+    filter: "nightcore",
+    formats: [
+      {
+        id: generateRandomId(),
+        constraint: "(nightcore)::[default]",
+        template:
+          "{artist},{title},{title} nightcore,{title} sped up,{title} sped up {artist},{artist} {title},{artist} {title} sped up,{artist} nightcore,{artist} sped up,nightcore",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(nightcore)::[feature-1]",
+        template: "{firstFeature},{artist} {firstFeature},{firstFeature} {title},title {firstFeature}",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(nightcore)::includes[default]&&[feature-1]",
+        template:
+          "{artist},{title},{title} nightcore,{title} sped up,{title} sped up {artist},{artist} {title},{artist} {title} sped up,{artist} nightcore,{artist} sped up,nightcore,{firstFeature},{artist} {firstFeature},{firstFeature} {title},title {firstFeature}",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(nightcore)::[feature-2]",
+        template: "{secondFeature},{artist} {secondFeature},{secondFeature} {title},title {secondFeature}",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(nightcore)::includes[default]&&[feature-1]&&[feature-2]",
+        template:
+          "{artist},{title},{title} nightcore,{title} sped up,{title} sped up {artist},{artist} {title},{artist} {title} sped up,{artist} nightcore,{artist} sped up,nightcore,{firstFeature},{artist} {firstFeature},{firstFeature} {title},title {firstFeature},{secondFeature},{artist} {secondFeature},{secondFeature} {title},title {secondFeature}",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(nightcore)::[feature-3]",
+        template: "{thirdFeature},{artist} {thirdFeature},{thirdFeature} {title},title {thirdFeature}",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(nightcore)::includes[default]&&[feature-1]&&[feature-2]&&[feature-3]",
+        template:
+          "{artist},{title},{title} nightcore,{title} sped up,{title} sped up {artist},{artist} {title},{artist} {title} sped up,{artist} nightcore,{artist} sped up,nightcore,{firstFeature},{artist} {firstFeature},{firstFeature} {title},title {firstFeature},{secondFeature},{artist} {secondFeature},{secondFeature} {title},title {secondFeature},{thirdFeature},{artist} {thirdFeature},{thirdFeature} {title},title {thirdFeature}",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(nightcore)::[@tiktok=true@]",
+        template: "{artist} {title} sped up tiktok remix,{title} sped up tiktok version",
+      },
+    ],
+  },
 ];


### PR DESCRIPTION
This pull request adds new template string format configurations specifically for the "nightcore" filter to the `TEMPLATE_STRING_FORMAT_LIST` in `template-string-format-list.ts`. These configurations allow for various combinations of features (such as first, second, and third features) and special cases like TikTok remixes.

New "nightcore" template formats:

* Added a new entry for the "nightcore" filter with multiple template formats, supporting default, feature-based, and TikTok-specific constraints.
* Each format includes a unique constraint and template string, enabling more flexible and comprehensive naming for "nightcore" tracks, including combinations of artist, title, and up to three features.