### PR TITLE
feat: complete slowed string format template page

### DIFF
--- a/src/lib/helpers/tags/slowed-reverb-tags.ts
+++ b/src/lib/helpers/tags/slowed-reverb-tags.ts
@@ -6,26 +6,27 @@ export const slowedReverbTags = (artist: string, title: string, features: string
   let feats = features.split(",").map((feat) => feat.trim());
 
   // First feature
-  const firstFeat = feats[0];
+  const firstFeature = feats[0];
 
   if (features !== "none" && (tiktok === "false" || tiktok === "" || tiktok !== "true")) {
-    tags += `,${firstFeat} ${title} slowed,${artist} ${firstFeat} ${title} slowed,${firstFeat}`;
+    tags += `,${firstFeature} ${title} slowed,${artist} ${firstFeature} ${title} slowed,${firstFeature}`;
 
     // Second Feature
     if (features.length === 2) {
-      const secondFeat = feats[1];
-      tags += `,${secondFeat}`;
+      const secondFeature = feats[1];
+
+      tags += `,${secondFeature},${artist} ${secondFeature},${secondFeature} ${title},title ${secondFeature}`;
     }
 
     // Third feature
     if (feats.length === 3) {
       const thirdFeature = feats[2];
-      tags += `,${thirdFeature}`;
+      tags += `,${thirdFeature},${artist} ${thirdFeature},${thirdFeature} ${title},title ${thirdFeature}`;
     }
   }
 
   if (tiktok === "true") {
-    tags += `,slowed tiktok songs`;
+    tags += `,slowed tiktok songs,${title} slowed down tiktok version`;
   }
 
   return tags;

--- a/src/lib/template-string-format-list.ts
+++ b/src/lib/template-string-format-list.ts
@@ -155,4 +155,54 @@ export const TEMPLATE_STRING_FORMAT_LIST: TemplateStringFormatList[] = [
       },
     ],
   },
+  {
+    id: generateRandomId(),
+    filter: "slowed",
+    formats: [
+      {
+        id: generateRandomId(),
+        constraint: "(slowed)::[default]",
+        template:
+          "{artist},{title},{artist} {title},{artist} {title} slowed,{artist} {title} slowed reverb,{artist} {title} slowed to perfection,{title} {artist},{title} slowed,{artist} - {title},{artist} - {title} slowed,{artist} - {title} slowed reverb,{title} slowed to perfection,{artist} {title} slowed and reverb,slowed and reverb songs",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(slowed)::[feature-1]",
+        template: "{firstFeature} {title} slowed,{artist} {firstFeature} {title} slowed,{firstFeature}",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(slowed)::includes[default]&&[feature-1]",
+        template:
+          "{artist},{title},{artist} {title},{artist} {title} slowed,{artist} {title} slowed reverb,{artist} {title} slowed to perfection,{title} {artist},{title} slowed,{artist} - {title},{artist} - {title} slowed,{artist} - {title} slowed reverb,{title} slowed to perfection,{artist} {title} slowed and reverb,slowed and reverb songs,{firstFeature} {title} slowed,{artist} {firstFeature} {title} slowed,{firstFeature}",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(slowed)::[feature-2]",
+        template: "{secondFeature},{artist} {secondFeature},{secondFeature} {title},title {secondFeature}",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(slowed)::includes[default]&&[feature-1]&&[feature-2]",
+        template:
+          "{artist},{title},{artist} {title},{artist} {title} slowed,{artist} {title} slowed reverb,{artist} {title} slowed to perfection,{title} {artist},{title} slowed,{artist} - {title},{artist} - {title} slowed,{artist} - {title} slowed reverb,{title} slowed to perfection,{artist} {title} slowed and reverb,slowed and reverb songs,{firstFeature} {title} slowed,{artist} {firstFeature} {title} slowed,{firstFeature},{secondFeature},{artist} {secondFeature},{secondFeature} {title},title {secondFeature}",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(slowed)::[feature-3]",
+        template: "{thirdFeature},{artist} {thirdFeature},{thirdFeature} {title},title {thirdFeature}",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(slowed)::includes[default]&&[feature-1]&&[feature-2]&&[feature-3]",
+        template:
+          "{artist},{title},{artist} {title},{artist} {title} slowed,{artist} {title} slowed reverb,{artist} {title} slowed to perfection,{title} {artist},{title} slowed,{artist} - {title},{artist} - {title} slowed,{artist} - {title} slowed reverb,{title} slowed to perfection,{artist} {title} slowed and reverb,slowed and reverb songs,{firstFeature} {title} slowed,{artist} {firstFeature} {title} slowed,{firstFeature},{secondFeature},{artist} {secondFeature},{secondFeature} {title},title {secondFeature},{thirdFeature},{artist} {thirdFeature},{thirdFeature} {title},title {thirdFeature}",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(slowed)::[@tiktok=true@]",
+        template: "slowed tiktok songs,{title} slowed down tiktok version",
+      },
+    ],
+  },
 ];


### PR DESCRIPTION
This pull request enhances the logic for generating tags related to "slowed reverb" tracks and introduces a new set of template string formats specifically for slowed tracks. The changes improve the granularity and flexibility of tag generation, especially when multiple featured artists are present, and add richer support for slowed track scenarios in the template system.

**Enhancements to slowed reverb tag generation:**

- Improved the tag generation logic in `slowedReverbTags` to use clearer variable names (`firstFeature`, `secondFeature`, `thirdFeature`) and to include more comprehensive tags when multiple features are present, such as combinations with the artist and title. Also added more descriptive tags for TikTok scenarios.

**Expansion of template string formats:**

- Added a new entry to `TEMPLATE_STRING_FORMAT_LIST` for the "slowed" filter in `template-string-format-list.ts`, providing a variety of templates for different combinations of features and TikTok context. This allows tags to be generated in a more structured and context-aware manner for slowed tracks.