### PR TITLE
feat: complete letra string format template page

### DIFF
--- a/src/lib/template-string-format-list.ts
+++ b/src/lib/template-string-format-list.ts
@@ -205,4 +205,58 @@ export const TEMPLATE_STRING_FORMAT_LIST: TemplateStringFormatList[] = [
       },
     ],
   },
+  {
+    id: generateRandomId(),
+    filter: "letra",
+    formats: [
+      {
+        id: generateRandomId(),
+        constraint: "(letra)::[default]",
+        template:
+          "{artist},{title},{artist} {title} letra,{artist} {title},{title} {artist},{title} letra,letra {title},letra {title} {artist},{artist} letra,{artist} letra {title},{title} letra {artist},letra {artist},{artist} - {title},{artist} - {title}",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(letra)::[feature-1]",
+        template:
+          "{firstFeature} {title},{artist} {firstFeature} {title},{firstFeature} {title} letra,{title} {firstFeature},{artist} {firstFeature},{firstFeature} {artist},{firstFeature}",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(letra)::includes[default]&&[feature-1]",
+        template:
+          "{artist},{title},{artist} {title} letra,{artist} {title},{title} {artist},{title} letra,letra {title},letra {title} {artist},{artist} letra,{artist} letra {title},{title} letra {artist},letra {artist},{artist} - {title},{artist} - {title},{firstFeature} {title},{artist} {firstFeature} {title},{firstFeature} {title} letra,{title} {firstFeature},{artist} {firstFeature},{firstFeature} {artist},{firstFeature}",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(letra)::[feature-2]",
+        template:
+          "{secondFeature},{secondFeature} {title} letra,{secondFeature} {title},{artist} {secondFeature},{title} {secondFeature}",
+      },
+
+      {
+        id: generateRandomId(),
+        constraint: "(letra)::includes[default]&&[feature-1]&&[feature-2]",
+        template:
+          "{artist},{title},{artist} {title} letra,{artist} {title},{title} {artist},{title} letra,letra {title},letra {title} {artist},{artist} letra,{artist} letra {title},{title} letra {artist},letra {artist},{artist} - {title},{artist} - {title},{firstFeature} {title},{artist} {firstFeature} {title},{firstFeature} {title} letra,{title} {firstFeature},{artist} {firstFeature},{firstFeature} {artist},{firstFeature},{secondFeature},{secondFeature} {title} letra,{secondFeature} {title},{artist} {secondFeature},{title} {secondFeature}",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(letra)::[feature-3]",
+        template:
+          "{thirdFeature},{thirdFeature} {title} letra,{thirdFeature} {title},{artist} {thirdFeature},{title} {thirdFeature}",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(letra)::includes[default]&&[feature-1]&&[feature-2]&&[feature-3]",
+        template:
+          "{artist},{title},{artist} {title} letra,{artist} {title},{title} {artist},{title} letra,letra {title},letra {title} {artist},{artist} letra,{artist} letra {title},{title} letra {artist},letra {artist},{artist} - {title},{artist} - {title},{firstFeature} {title},{artist} {firstFeature} {title},{firstFeature} {title} letra,{title} {firstFeature},{artist} {firstFeature},{firstFeature} {artist},{firstFeature},{secondFeature},{secondFeature} {title} letra,{secondFeature} {title},{artist} {secondFeature},{title} {secondFeature},{thirdFeature},{thirdFeature} {title} letra,{thirdFeature} {title},{artist} {thirdFeature},{title} {thirdFeature}",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(letra)::[@tiktok=true@]",
+        template: "{title} tiktok,{artist} tiktok,latin tiktok",
+      },
+    ],
+  },
 ];


### PR DESCRIPTION
This pull request adds a new set of template string formats related to the "letra" filter in the `TEMPLATE_STRING_FORMAT_LIST` array. These new templates support various combinations of song metadata, including artist, title, and up to three featured artists, as well as a TikTok-specific format.

**Enhancements to template string formats:**

* Added a new entry to `TEMPLATE_STRING_FORMAT_LIST` for the "letra" filter, including templates for default, feature-1, feature-2, feature-3, and TikTok constraints, as well as combinations of these features.