### PR TITLE
feat: complete testo string format template page

### DIFF
--- a/src/lib/helpers/tags/testo-lyrics.ts
+++ b/src/lib/helpers/tags/testo-lyrics.ts
@@ -28,7 +28,7 @@ export const testoTags = (artist: string, title: string, features: string, tikto
   }
 
   if (tiktok === "true") {
-    tags += `,${title} tiktok,${artist} tiktok`;
+    tags += `,${title} tiktok,${artist} tiktok, testo tiktok, italian tiktok`;
   }
 
   return tags;

--- a/src/lib/template-string-format-list.ts
+++ b/src/lib/template-string-format-list.ts
@@ -259,4 +259,57 @@ export const TEMPLATE_STRING_FORMAT_LIST: TemplateStringFormatList[] = [
       },
     ],
   },
+  {
+    id: generateRandomId(),
+    filter: "testo",
+    formats: [
+      {
+        id: generateRandomId(),
+        constraint: "(testo)::[default]",
+        template:
+          "{artist},{title},{artist} {title} testo,{artist} {title},{title} {artist},{title} testo,testo {title},testo {title} {artist},{artist} testo,{artist} testo {title},{title} testo {artist},testo {artist},{artist} - {title},{artist} - {title} testo,testo",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(testo)::[feature-1]",
+        template:
+          "{firstFeature} {title},{artist} {firstFeature} {title},{firstFeature} {title} testo,{title} {firstFeature},{artist} {firstFeature},{firstFeature} {artist},{firstFeature}",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(testo)::includes[default]&&[feature-1]",
+        template:
+          "{artist},{title},{artist} {title} testo,{artist} {title},{title} {artist},{title} testo,testo {title},testo {title} {artist},{artist} testo,{artist} testo {title},{title} testo {artist},testo {artist},{artist} - {title},{artist} - {title} testo,testo,{firstFeature} {title},{artist} {firstFeature} {title},{firstFeature} {title} testo,{title} {firstFeature},{artist} {firstFeature},{firstFeature} {artist},{firstFeature}",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(testo)::[feature-2]",
+        template:
+          "{secondFeature},{secondFeature} {title} testo,{secondFeature} {title},{artist} {secondFeature},{title} {secondFeature}",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(testo)::includes[default]&&[feature-1]&&[feature-2]",
+        template:
+          "{artist},{title},{artist} {title} testo,{artist} {title},{title} {artist},{title} testo,testo {title},testo {title} {artist},{artist} testo,{artist} testo {title},{title} testo {artist},testo {artist},{artist} - {title},{artist} - {title} testo,testo,{firstFeature} {title},{artist} {firstFeature} {title},{firstFeature} {title} testo,{title} {firstFeature},{artist} {firstFeature},{firstFeature} {artist},{firstFeature},{secondFeature},{secondFeature} {title} testo,{secondFeature} {title},{artist} {secondFeature},{title} {secondFeature}",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(testo)::[feature-3]",
+        template:
+          "{thirdFeature},{thirdFeature} {title} testo,{thirdFeature} {title},{artist} {thirdFeature},{title} {thirdFeature}",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(testo)::includes[default]&&[feature-1]&&[feature-2]&&[feature-3]",
+        template:
+          "{artist},{title},{artist} {title} testo,{artist} {title},{title} {artist},{title} testo,testo {title},testo {title} {artist},{artist} testo,{artist} testo {title},{title} testo {artist},testo {artist},{artist} - {title},{artist} - {title} testo,testo,{firstFeature} {title},{artist} {firstFeature} {title},{firstFeature} {title} testo,{title} {firstFeature},{artist} {firstFeature},{firstFeature} {artist},{firstFeature},{secondFeature},{secondFeature} {title} testo,{secondFeature} {title},{artist} {secondFeature},{title} {secondFeature},{thirdFeature},{thirdFeature} {title} testo,{thirdFeature} {title},{artist} {thirdFeature},{title} {thirdFeature}",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(testo)::[@tiktok=true@]",
+        template: "{title} tiktok,{artist} tiktok, testo tiktok, italian tiktok",
+      },
+    ],
+  },
 ];


### PR DESCRIPTION
This pull request adds comprehensive support for "testo" (lyrics) tag generation and formatting, enhancing both the tag helper logic and the template string format list. The changes introduce new templates for various combinations of artist, title, and featured artists, as well as improved TikTok-related tagging.

Tag generation improvements:

* Expanded the TikTok-specific tags in `testoTags` to include "testo tiktok" and "italian tiktok" for better coverage of Italian lyrics content.

Template formatting enhancements:

* Added a new "testo" entry to `TEMPLATE_STRING_FORMAT_LIST`, providing detailed templates for different scenarios (default, feature-1/2/3, and TikTok), ensuring flexible and accurate tag generation for lyrics-related content.