### PR TITLE
feat: add the additional optional tags option

### DIFF
--- a/src/pages/api/v1/generate.ts
+++ b/src/pages/api/v1/generate.ts
@@ -34,7 +34,6 @@ import { FORMAT } from "@/lib/format";
 import { error } from "@/lib/error";
 import { GENRE } from "@/lib/genre";
 import { v4 as uuidv4 } from "uuid";
-import { SourceTextModule } from "vm";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   // Check if the request method is GET


### PR DESCRIPTION
This pull request updates the `src/pages/api/v1/generate.ts` endpoint to support the automatic addition of seasonal tags (Christmas or Halloween) based on a new optional format segment in the song title. The most significant changes are:

**Support for Seasonal Tagging:**

* The handler now splits the `finalTitle` on a backslash (`This pull request updates the `src/pages/api/v1/generate.ts` endpoint to support the automatic addition of seasonal tags (Christmas or Halloween) based on a new optional format segment in the song title. The most significant changes are:

**Support for Seasonal Tagging:**

). If a second segment is present, it is interpreted as an "additional format" (e.g., `christmas` or `halloween`) and removed from the title.
* If the additional format matches a list of Christmas or Halloween keywords (case-insensitive), the handler appends relevant seasonal tags (including the current year) to the generated tags string.

**Code Organization:**

* Imported `SourceTextModule` from `vm`, though it is not used in the shown changes.