### PR TITLE
feat: add none format and dance genre

### DIFF
--- a/src/lib/compute-final-hashtag.ts
+++ b/src/lib/compute-final-hashtag.ts
@@ -14,6 +14,8 @@ export const computeFinalHashtags = (hashtag: string): string => {
       return "Nightcore";
     case "testo":
       return "Testo";
+    case "none":
+      return "";
     default:
       return "Lyrics";
   }

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -6,4 +6,5 @@ export const FORMAT = {
   testo: "testo",
   phonk: "phonk",
   letra: "letra",
+  none: "none",
 };

--- a/src/lib/genre.ts
+++ b/src/lib/genre.ts
@@ -2,6 +2,7 @@ export const GENRE = {
   country: "country",
   italian: "italian",
   hiphop: "hiphop",
+  dance: "dance",
   phonk: "phonk",
   latin: "latin",
   funk: "funk",

--- a/src/lib/helpers/tags/none-tags.ts
+++ b/src/lib/helpers/tags/none-tags.ts
@@ -1,0 +1,35 @@
+export const noneTags = (artist: string, title: string, features: string, tiktok: string): string => {
+  // Tags
+  let tags = `${artist} ${title},${artist},${title},${title} ${artist},${artist} - ${title},${title} official audio,${artist} new song,${artist} music,${artist} ${title} official audio,${artist} ${title} song,${title} ${artist} audio`;
+
+  // Features
+  let feats = features.split(",").map((feat) => feat.trim());
+
+  // First feature
+  const firstFeature = feats[0];
+
+  // Features
+  if (features !== "none" && (tiktok === "false" || tiktok === "" || tiktok !== "true")) {
+    tags += `,${firstFeature},${artist} ${firstFeature},${firstFeature} ${title},${artist} ${firstFeature} ${title}`;
+
+    // Second feature
+    if (feats.length === 2) {
+      const secondFeature = feats[1];
+
+      tags += `,${secondFeature},${artist} ${secondFeature},${secondFeature} ${title},${artist} ${secondFeature} ${title}`;
+    }
+
+    // Third feature
+    if (feats.length === 3) {
+      const thirdFeature = feats[2];
+
+      tags += `,${thirdFeature},${artist} ${thirdFeature},${thirdFeature} ${title},${artist} ${thirdFeature} ${title}`;
+    }
+  }
+
+  if (tiktok === "true") {
+    tags += `,tiktok,${title} tiktok,trending tiktok,tiktok songs`;
+  }
+
+  return tags;
+};

--- a/src/lib/helpers/tags/remove-tags.ts
+++ b/src/lib/helpers/tags/remove-tags.ts
@@ -6,6 +6,7 @@ import { testoTagsRemove } from "./remove/testo-tags-remove";
 import { letraTagsRemove } from "./remove/letra-tags-remove";
 import { phonkTagsRemove } from "./remove/phonk-tags-remove";
 import { FORMAT } from "@/lib/format";
+import { noneTagsRemove } from "./remove/none-tags-remove";
 
 export const removeTags = (
   title: string,
@@ -48,6 +49,11 @@ export const removeTags = (
   // Phonk
   if (format === FORMAT.phonk) {
     return phonkTagsRemove(title, artist, features, tiktok, tags);
+  }
+
+  // None
+  if (format === FORMAT.none) {
+    return noneTagsRemove(title, artist, features, tiktok, tags);
   }
 
   return "";

--- a/src/lib/helpers/tags/remove/none-tags-remove.ts
+++ b/src/lib/helpers/tags/remove/none-tags-remove.ts
@@ -1,0 +1,126 @@
+import { tagsDeletionAlgorithm } from "./helpers/tags-deletion-algorithm";
+
+export const noneTagsRemove = (
+  title: string,
+  artist: string,
+  features: string,
+  tiktok: string,
+  tags: string
+): string => {
+  if (features === "none") {
+    const generateConcreteLeastEfficientTags = (artist: string, title: string) => {
+      const patterns: string[] = [
+        `${title} ${artist} audio`,
+        `${artist} - ${title}`,
+        `${artist} music`,
+        `${title} ${artist}`,
+        `${title} official audio`,
+        `${artist} ${title} official audio`,
+        `${artist} ${title} song`,
+        `${artist} new song`,
+        `${artist} ${title}`,
+        `${title}`,
+        `${artist}`,
+      ];
+
+      return patterns.map((pattern) => pattern.trim().toLowerCase());
+    };
+
+    const concreteLeastEfficientTags = generateConcreteLeastEfficientTags(artist, title);
+
+    return tagsDeletionAlgorithm(concreteLeastEfficientTags, tags.toLowerCase());
+  }
+
+  if (features !== "none") {
+    const generateConcreteLeastEfficientTags = (artist: string, title: string) => {
+      let feats = features.split(",").map((feat) => feat.trim());
+
+      const secondFeature = feats[1];
+      const firstFeature = feats[0];
+
+      if (feats.length === 1) {
+        const patterns: string[] = [
+          `${artist} ${firstFeature} ${title}`,
+          `${firstFeature} ${title}`,
+          `${artist} ${firstFeature}`,
+          `${title} ${artist} audio`,
+          `${artist} - ${title}`,
+          `${artist} music`,
+          `${title} ${artist}`,
+          `${title} official audio`,
+          `${artist} ${title} official audio`,
+          `${artist} ${title} song`,
+          `${artist} new song`,
+          `${firstFeature}`,
+          `${artist} ${title}`,
+          `${title}`,
+          `${artist}`,
+        ];
+
+        return patterns.map((pattern) => pattern.trim().toLowerCase());
+      } else if (feats.length === 2) {
+        const patterns: string[] = [
+          `${artist} ${secondFeature} ${title}`,
+          `${secondFeature} ${title}`,
+          `${artist} ${secondFeature}`,
+          `${artist} ${firstFeature} ${title}`,
+          `${firstFeature} ${title}`,
+          `${artist} ${firstFeature}`,
+          `${title} ${artist} audio`,
+          `${artist} - ${title}`,
+          `${artist} music`,
+          `${title} ${artist}`,
+          `${title} official audio`,
+          `${artist} ${title} official audio`,
+          `${artist} ${title} song`,
+          `${artist} new song`,
+          `${secondFeature}`,
+          `${firstFeature}`,
+          `${artist} ${title}`,
+          `${title}`,
+          `${artist}`,
+        ];
+
+        return patterns.map((pattern) => pattern.trim().toLowerCase());
+      } else if (feats.length === 3) {
+        const thirdFeature = feats[2];
+
+        const patterns: string[] = [
+          `${artist} ${secondFeature} ${title}`,
+          `${thirdFeature} ${title}`,
+          `${artist} ${thirdFeature}`,
+          `${artist} ${thirdFeature} ${title}`,
+          `${secondFeature} ${title}`,
+          `${artist} ${secondFeature}`,
+          `${artist} ${firstFeature} ${title}`,
+          `${firstFeature} ${title}`,
+          `${artist} ${firstFeature}`,
+          `${title} ${artist} audio`,
+          `${artist} - ${title}`,
+          `${artist} music`,
+          `${title} ${artist}`,
+          `${title} official audio`,
+          `${artist} ${title} official audio`,
+          `${artist} ${title} song`,
+          `${artist} new song`,
+          `${thirdFeature}`,
+          `${secondFeature}`,
+          `${firstFeature}`,
+          `${artist} ${title}`,
+          `${title}`,
+          `${artist}`,
+        ];
+
+        return patterns.map((pattern) => pattern.trim().toLowerCase());
+      }
+
+      return [];
+    };
+
+    const concreteLeastEfficientTags = generateConcreteLeastEfficientTags(artist, title);
+
+    return tagsDeletionAlgorithm(concreteLeastEfficientTags, tags.toLowerCase());
+  }
+
+  return "";
+};

--- a/src/lib/helpers/titles/none-titles.ts
+++ b/src/lib/helpers/titles/none-titles.ts
@@ -1,0 +1,6 @@
+export const noneTitles = (artist: string, title: string, feats: string[]): string => {
+  switch (feats.length) {
+    default:
+      return `${artist} - ${title}=${title}`;
+  }
+};

--- a/src/lib/return-computed-format.ts
+++ b/src/lib/return-computed-format.ts
@@ -20,6 +20,8 @@ export const returnComputedFormat = (format: string) => {
       return "phonk";
     case "letra":
       return "letra";
+    case "none":
+      return "none";
     default:
       return "lyrics";
   }

--- a/src/lib/validate-provided-genre.ts
+++ b/src/lib/validate-provided-genre.ts
@@ -16,6 +16,8 @@ export const validateProvidedGenre = (genre: string): boolean => {
       return true;
     case GENRE.phonk:
       return true;
+    case GENRE.dance:
+      return true;
     case GENRE.latin:
       return true;
     case GENRE.italian:

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -542,6 +542,7 @@ export default function Home() {
                     { value: FORMAT.letra, text: "Letra" },
                     { value: FORMAT.testo, text: "Testo" },
                     { value: FORMAT.phonk, text: "Phonk" },
+                    { value: FORMAT.none, text: "None" },
                   ].map((option) => (
                     <option className="font-inter" key={option.value} value={option.value}>
                       {option.text}
@@ -573,6 +574,7 @@ export default function Home() {
                     { value: GENRE.country, text: "Country" },
                     { value: GENRE.latin, text: "Latin" },
                     { value: GENRE.italian, text: "Italian" },
+                    { value: GENRE.dance, text: "Dance" },
                     { value: GENRE.phonk, text: "Phonk" },
                     { value: GENRE.pop, text: "Pop" },
                     { value: GENRE.rap, text: "Rap" },


### PR DESCRIPTION
This pull request adds support for a new "none" format and a new "dance" genre throughout the codebase. It introduces logic for generating and removing tags and titles for the "none" format, updates validation and selection options, and ensures that hashtags and genre-specific tags are handled correctly for these new options.

**Support for "none" format:**

- Added "none" as a valid format in `FORMAT`, updated format computation, and included it in the format selection dropdown (`src/lib/format.ts`, `src/lib/compute-final-hashtag.ts`, `src/lib/return-computed-format.ts`, `src/pages/index.tsx`) [[1]](diffhunk://#diff-769f3879f73f128cb8edff98945340a348a660d9d40644f5ee246217e90107c8R9) [[2]](diffhunk://#diff-730d30137bdc440e9c0e96bc5897a47a54c81144776e2e69609d4b5a05ea25a8R17-R18) [[3]](diffhunk://#diff-532a66d2f9326766c68774ed1b48cbc1029de1ceb1ac2a422b414238e71ea670R23-R24) [[4]](diffhunk://#diff-18e0d4553c97cfc420e938ccafb4e3a688e782fa4512ba4ceae3e2a6f24c1987R545)
- Implemented `noneTags` and `noneTitles` helpers to generate appropriate tags and titles for the "none" format, and integrated them into the API handler (`src/lib/helpers/tags/none-tags.ts`, `src/lib/helpers/titles/none-titles.ts`, `src/pages/api/v1/generate.ts`) [[1]](diffhunk://#diff-476075410b11e0a476bfe724b3e1ce9ec16c93b121201fd17471103348a189c1R1-R35) [[2]](diffhunk://#diff-1257ef5f62cafcec738fb9e233874a89654f4a96371b6deb1277fceeed43792fR1-R6) [[3]](diffhunk://#diff-6666d0c2522a2efc68c3e0ca5ee4ab9b5d5b1041e47ededf0e9bfea14c2b061bR24-R31) [[4]](diffhunk://#diff-6666d0c2522a2efc68c3e0ca5ee4ab9b5d5b1041e47ededf0e9bfea14c2b061bR296-R297) [[5]](diffhunk://#diff-6666d0c2522a2efc68c3e0ca5ee4ab9b5d5b1041e47ededf0e9bfea14c2b061bR483-R498)
- Added `noneTagsRemove` and integrated it into the tag removal logic to support cleaning up "none" format tags (`src/lib/helpers/tags/remove/none-tags-remove.ts`, `src/lib/helpers/tags/remove-tags.ts`) [[1]](diffhunk://#diff-57ed1985a33dcc8a14bbd089d9271f6f6d85c009887d86471eb1d31ade90dc37R1-R126) [[2]](diffhunk://#diff-7d7ade67a528c45bb4dea4ead601ffdd28cf863b900172ad181fbd40b5c8ad60R9) [[3]](diffhunk://#diff-7d7ade67a528c45bb4dea4ead601ffdd28cf863b900172ad181fbd40b5c8ad60R54-R58)

**Support for "dance" genre:**

- Added "dance" as a valid genre in `GENRE`, updated validation, and included it in the genre selection dropdown (`src/lib/genre.ts`, `src/lib/validate-provided-genre.ts`, `src/pages/index.tsx`) [[1]](diffhunk://#diff-94deff86867dab76048c22355c4a68a562f4eb415d94e14e362df34e23500e89R5) [[2]](diffhunk://#diff-126890372bdb5044b5e54a57d6129b83ae9d808a7b9b6e213dde3034eb35ba7cR19-R20) [[3]](diffhunk://#diff-18e0d4553c97cfc420e938ccafb4e3a688e782fa4512ba4ceae3e2a6f24c1987R577)
- Appended dance-specific tags when the genre is "dance" in the API handler (`src/pages/api/v1/generate.ts`)

**Improvements to API handler logic:**

- Adjusted logic to prevent processing formats containing "remix" as a standard format (`src/pages/api/v1/generate.ts`)
- Ensured that empty hashtags are not included when the format is "none" (`src/pages/api/v1/generate.ts`)