### PR TITLE
feat: add 'none' format to template string format list

### DIFF
--- a/src/lib/format-list.ts
+++ b/src/lib/format-list.ts
@@ -29,4 +29,8 @@ export const FORMAT_LIST: FormatList[] = [
     name: "Phonk",
     slug: "phonk",
   },
+  {
+    name: "None",
+    slug: "none"
+  }
 ];

--- a/src/lib/template-string-format-list.ts
+++ b/src/lib/template-string-format-list.ts
@@ -364,4 +364,55 @@ export const TEMPLATE_STRING_FORMAT_LIST: TemplateStringFormatList[] = [
       },
     ],
   },
+
+  {
+    id: generateRandomId(),
+    filter: "none",
+    formats: [
+      {
+        id: generateRandomId(),
+        constraint: "(none)::[default]",
+        template:
+          "{artist} {title},{artist},{title},{title} {artist},{artist} - {title},{title} official audio,{artist} new song,{artist} music,{artist} {title} official audio,{artist} {title} song,{title} {artist} audio",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(none)::[feature-1]",
+        template: "{firstFeature},{artist} {firstFeature},{firstFeature} {title},{artist} {firstFeature} {title}",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(none)::includes[default]&&[feature-1]",
+        template:
+          "{artist} {title},{artist},{title},{title} {artist},{artist} - {title},{title} official audio,{artist} new song,{artist} music,{artist} {title} official audio,{artist} {title} song,{title} {artist} audio,{firstFeature},{artist} {firstFeature},{firstFeature} {title},{artist} {firstFeature} {title}",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(none)::[feature-2]",
+        template: "{secondFeature},{artist} {secondFeature},{secondFeature} {title},{artist} {secondFeature} {title}",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(none)::includes[default]&&[feature-1]&&[feature-2]",
+        template:
+          "{artist} {title},{artist},{title},{title} {artist},{artist} - {title},{title} official audio,{artist} new song,{artist} music,{artist} {title} official audio,{artist} {title} song,{title} {artist} audio,{firstFeature},{artist} {firstFeature},{firstFeature} {title},{artist} {firstFeature} {title},{secondFeature},{artist} {secondFeature},{secondFeature} {title},{artist} {secondFeature} {title}",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(none)::[feature-3]",
+        template: "{thirdFeature},{artist} {thirdFeature},{thirdFeature} {title},{artist} {thirdFeature} {title}",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(none)::includes[default]&&[feature-1]&&[feature-2]&&[feature-3]",
+        template:
+          "{artist} {title},{artist},{title},{title} {artist},{artist} - {title},{title} official audio,{artist} new song,{artist} music,{artist} {title} official audio,{artist} {title} song,{title} {artist} audio,{firstFeature},{artist} {firstFeature},{firstFeature} {title},{artist} {firstFeature} {title},{secondFeature},{artist} {secondFeature},{secondFeature} {title},{artist} {secondFeature} {title},{thirdFeature},{artist} {thirdFeature},{thirdFeature} {title},{artist} {thirdFeature} {title}",
+      },
+      {
+        id: generateRandomId(),
+        constraint: "(none)::[@tiktok=true@]",
+        template: "tiktok,{title} tiktok,trending tiktok,tiktok songs",
+      },
+    ],
+  },
 ];


### PR DESCRIPTION
This pull request adds support for a new "None" format option in the application. The changes ensure that both the format list and the template string format list now include the "None" format, along with its associated template constraints and templates.

Format support:

* Added a new "None" format to the `FORMAT_LIST` array in `src/lib/format-list.ts`.

Template string formats:

* Added a comprehensive set of template string formats and constraints for the "None" format in `TEMPLATE_STRING_FORMAT_LIST` in `src/lib/template-string-format-list.ts`, covering various combinations of features and TikTok-related templates.