### PR TITLE
fix: key prop problem

### DIFF
--- a/src/components/documentation/sections/WhatToProvide.tsx
+++ b/src/components/documentation/sections/WhatToProvide.tsx
@@ -49,21 +49,21 @@ export const WhatToProvide = (props: { endpoint: "generate" | "length" }) => {
           <tbody>
             {rowsGenerate.map((row, rowIndex) => (
               <tr key={rowIndex} className="border border-teal-100">
-                {row.map((value, colIndex) => (
-                  <>
-                    {value.list ? (
-                      <TdElement col={colIndex}>
-                        <ul className="list-disc ml-4">
-                          {value.list.map((val) => (
-                            <li>{val}</li>
-                          ))}
-                        </ul>
-                      </TdElement>
-                    ) : (
-                      <TdElement col={colIndex}>{value.placeholder}</TdElement>
-                    )}
-                  </>
-                ))}
+                {row.map((value, index) =>
+                  value.list ? (
+                    <TdElement key={index} col={index}>
+                      <ul className="list-disc ml-4">
+                        {value.list.map((val) => (
+                          <li key={val}>{val}</li>
+                        ))}
+                      </ul>
+                    </TdElement>
+                  ) : (
+                    <TdElement key={index} col={index}>
+                      {value.placeholder}
+                    </TdElement>
+                  )
+                )}
               </tr>
             ))}
           </tbody>
@@ -74,7 +74,9 @@ export const WhatToProvide = (props: { endpoint: "generate" | "length" }) => {
             {rowsLength.map((row, rowIndex) => (
               <tr key={rowIndex} className="border border-teal-100">
                 {row.map((value, index) => (
-                  <TdElement col={index}>{value.placeholder}</TdElement>
+                  <TdElement key={index} col={index}>
+                    {value.placeholder}
+                  </TdElement>
                 ))}
               </tr>
             ))}


### PR DESCRIPTION
This pull request updates the rendering logic for table rows in the `WhatToProvide` component to improve React key usage and ensure best practices for list rendering. The changes focus on adding unique `key` props to elements in mapped lists, which helps React efficiently update and reconcile components.

**Improvements to table row rendering:**

* Added unique `key` props to `TdElement` and `li` elements within mapped lists in the `WhatToProvide` component to prevent React key warnings and improve performance. [[1]](diffhunk://#diff-12b7bb2bc834198a28ea17d65df324e8aa812c3885c6b2986f77e710c6ce8b9aL52-L66) [[2]](diffhunk://#diff-12b7bb2bc834198a28ea17d65df324e8aa812c3885c6b2986f77e710c6ce8b9aL77-R79)