### PR TITLE
fix: discord webhook log format text

### DIFF
--- a/src/lib/send-discord-webhook.ts
+++ b/src/lib/send-discord-webhook.ts
@@ -46,7 +46,7 @@ export const sendDiscordWebhook = async (
             },
             {
               name: "Format:",
-              value: computeFinalHashtags(format).replace("SlowedReverb", "Slowed & Reverb"),
+              value: computeFinalHashtags(format).replace("SlowedReverb", "Slowed & Reverb").replace("", "None"),
               inline: true,
             },
             {


### PR DESCRIPTION
This pull request makes a minor update to the `sendDiscordWebhook` function to further refine the formatting of the "Format" field in Discord webhook messages. 

- The value for the "Format:" field now also replaces empty strings with "None" in addition to the existing "SlowedReverb" to "Slowed & Reverb" replacement.