### PR TITLE
fix: discord format webhook value

### DIFF
--- a/src/lib/send-discord-webhook.ts
+++ b/src/lib/send-discord-webhook.ts
@@ -1,7 +1,8 @@
-import { NextApiResponse } from "next";
-import { error } from "./error";
+import { capitalizeFirstLetter } from "./capitalize-first-letter";
 import { computeFinalHashtags } from "./compute-final-hashtag";
 import { countTagsLength } from "./count-tags-length";
+import { NextApiResponse } from "next";
+import { error } from "./error";
 
 export const sendDiscordWebhook = async (
   customFormatString: string,
@@ -41,20 +42,22 @@ export const sendDiscordWebhook = async (
             },
             {
               name: "Tiktok:",
-              value: tiktok,
+              value: capitalizeFirstLetter(tiktok),
               inline: true,
             },
             {
               name: "Format:",
-              value: computeFinalHashtags(format)
-                .replace("SlowedReverb", "Slowed & Reverb")
-                .replace("", "None")
-                .replace("NoneLyrics", "Lyrics"),
+              value:
+                format.toLowerCase() === "none"
+                  ? "None"
+                  : computeFinalHashtags(format)
+                      .replace("SlowedReverb", "Slowed & Reverb")
+                      .replace("BassBoosted", "Bass Boosted"),
               inline: true,
             },
             {
               name: "Channel:",
-              value: channel,
+              value: channel.toLowerCase() === "none" ? "None" : channel,
               inline: true,
             },
             {
@@ -64,12 +67,12 @@ export const sendDiscordWebhook = async (
             },
             {
               name: "Features:",
-              value: features.length ? features : "None",
+              value: features.length ? (features.toLowerCase() === "none" ? "None" : features) : "None",
               inline: true,
             },
             {
               name: "Log:",
-              value: log,
+              value: capitalizeFirstLetter(log),
               inline: true,
             },
             {
@@ -87,11 +90,11 @@ export const sendDiscordWebhook = async (
             },
             {
               name: "Removed:",
-              value: tagsToBeRemoved.length ? tagsToBeRemoved : "none",
+              value: tagsToBeRemoved.length ? tagsToBeRemoved : "None",
             },
             {
               name: "Custom:",
-              value: customFormatString.length ? customFormatString : "none",
+              value: customFormatString.length ? customFormatString : "None",
             },
           ],
           footer: {

--- a/src/pages/api/v1/generate.ts
+++ b/src/pages/api/v1/generate.ts
@@ -245,7 +245,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       .replace(/(\.|'|!|\(.*$)/g, "")
       .trim();
   }
-  console.log(`Format: ${formatText}`);
 
   // If format text was found, process it.
   if (formatText.length && formatText.toLowerCase() !== "lyrics" && !formatText.toLowerCase().includes("remix")) {


### PR DESCRIPTION
This pull request focuses on improving the formatting and consistency of values sent in Discord webhook messages, particularly by standardizing case and handling of "None" values. It also includes a minor cleanup in the API handler.

Formatting and consistency improvements in Discord webhook payload:

* Standardized the display of "None" values for fields such as `Format`, `Channel`, `Features`, `Removed`, and `Custom`, ensuring consistent capitalization and logic for when to show "None" instead of empty strings or lowercase "none". [[1]](diffhunk://#diff-66905111dae3c169def223c7b1d20d7cfd777a3957c5e6754351307292418b98L44-R60) [[2]](diffhunk://#diff-66905111dae3c169def223c7b1d20d7cfd777a3957c5e6754351307292418b98L67-R75) [[3]](diffhunk://#diff-66905111dae3c169def223c7b1d20d7cfd777a3957c5e6754351307292418b98L90-R97)
* Applied the `capitalizeFirstLetter` utility to fields like `Tiktok` and `Log` to ensure their values are consistently capitalized in the webhook. [[1]](diffhunk://#diff-66905111dae3c169def223c7b1d20d7cfd777a3957c5e6754351307292418b98L44-R60) [[2]](diffhunk://#diff-66905111dae3c169def223c7b1d20d7cfd777a3957c5e6754351307292418b98L67-R75)
* Improved the formatting of the `Format` field by replacing specific keywords (e.g., "BassBoosted" → "Bass Boosted") for better readability.

Code cleanup:

* Removed an unnecessary `console.log` statement from the API handler in `generate.ts` to reduce noise in server logs.