### PR TITLE
feat: support ampersand formats

### DIFF
--- a/src/pages/api/v1/generate.ts
+++ b/src/pages/api/v1/generate.ts
@@ -105,7 +105,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   //   });
   // }
 
-  if (/,|-/.test(artist)) {
+  if (/,|-|&/.test(artist)) {
     // Checks if the artist field reaches the character limit
     if (artist.length > ARTIST_INPUT_FIELD_CHARACTER_LIMIT_FORMATTED) {
       res.status(400).json({
@@ -169,7 +169,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   let remix = '';
 
   // Modified if statement to check for both standard hyphen and em dash
-  if (/,|-/.test(artist)) {
+  if (/,|-|&/.test(artist)) {
     // Determine which separator to use for splitting (standard hyphen or em dash)
     const separator = artist.includes('—') ? '—' : '-';
     const data = artist.split(separator);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -267,7 +267,7 @@ export default function Home() {
     }
 
     // Checks if the artist field reaches the character limit
-    if (/[-,]/.test(artist)) {
+    if (/[-,&]/.test(artist)) {
       // Check if artist input exceeds formatted character limit
       if (artist.length > ARTIST_INPUT_FIELD_CHARACTER_LIMIT_FORMATTED) {
         // Show error toast when character limit is exceeded
@@ -463,7 +463,7 @@ export default function Home() {
                 </p>
                 <CharacterLimit
                   limit={
-                    artist.includes("-") || artist.includes(",")
+                    artist.includes("-") || artist.includes(",") || artist.includes("&")
                       ? ARTIST_INPUT_FIELD_CHARACTER_LIMIT_FORMATTED
                       : ARTIST_INPUT_FIELD_CHARACTER_LIMIT
                   }


### PR DESCRIPTION
This pull request updates the validation and character limit logic for the `artist` input field to also account for the `&` character, in addition to the existing checks for commas and hyphens. This ensures that when an artist name contains an ampersand, the appropriate character limit and validation behavior is applied, improving consistency across the application.

**Artist input validation and character limit handling:**

* Updated regex checks in both the API handler (`src/pages/api/v1/generate.ts`) and the frontend (`src/pages/index.tsx`) to include `&` as a separator, ensuring that artist names containing an ampersand are handled consistently with those containing commas or hyphens. [[1]](diffhunk://#diff-6666d0c2522a2efc68c3e0ca5ee4ab9b5d5b1041e47ededf0e9bfea14c2b061bL108-R108) [[2]](diffhunk://#diff-6666d0c2522a2efc68c3e0ca5ee4ab9b5d5b1041e47ededf0e9bfea14c2b061bL172-R172) [[3]](diffhunk://#diff-18e0d4553c97cfc420e938ccafb4e3a688e782fa4512ba4ceae3e2a6f24c1987L270-R270)
* Modified the logic for determining the character limit in the `CharacterLimit` component to also check for the presence of `&`, so the correct limit is enforced in the UI.