### PR TITLE
feat: add genre page

### DIFF
--- a/src/lib/genre-list.ts
+++ b/src/lib/genre-list.ts
@@ -1,0 +1,36 @@
+import { FormatList } from '@/types/format-list';
+
+export const GENRE_LIST: FormatList[] = [
+  {
+    name: 'None',
+    slug: 'none',
+  },
+  {
+    name: 'Country',
+    slug: 'country',
+  },
+  {
+    name: 'Latin',
+    slug: 'latin',
+  },
+  {
+    name: 'Italian',
+    slug: 'italian',
+  },
+  {
+    name: 'Dance',
+    slug: 'dance',
+  },
+  {
+    name: 'Phonk',
+    slug: 'phonk',
+  },
+  {
+    name: 'Pop',
+    slug: 'pop',
+  },
+  {
+    name: 'Rap',
+    slug: 'rap',
+  },
+];

--- a/src/lib/seo/seo.ts
+++ b/src/lib/seo/seo.ts
@@ -21,6 +21,11 @@ export const seo = {
       description: 'Format',
       heading: 'Format',
     },
+    genre: {
+      title: 'Genre | Lyrics Tags Generator',
+      description: 'Genre',
+      heading: 'Genre',
+    },
     documentation: {
       title: 'Documentation | Lyrics Tags Generator',
       description: 'Documentation',

--- a/src/pages/genre.tsx
+++ b/src/pages/genre.tsx
@@ -1,0 +1,33 @@
+import { NoSupportedSizeScreenMessage } from '@/components/NoSupportedSizeScreenMessage';
+import { DevelopmentNav } from '@/components/DevelopmentNav';
+import { MainWrapper } from '@/components/MainWrapper';
+import { Container } from '@/components/Container';
+import { TagText } from '@/components/TagText';
+import { GENRE_LIST } from '@/lib/genre-list';
+import { Footer } from '@/components/Footer';
+import { Nav } from '@/components/Nav';
+import { Seo } from '@/components/Seo';
+import { seo } from '@/lib/seo/seo';
+
+export default function Genre() {
+  return (
+    <Container>
+      <Seo seoTitle={seo.page.genre.title} seoDescription={seo.page.genre.description} />
+      <NoSupportedSizeScreenMessage />
+      <DevelopmentNav />
+      <Nav />
+      <MainWrapper>
+        <h1 className="text-4xl font-black tracking-tight mt-8">{seo.page.genre.heading}</h1>
+        <p className="mt-4 text-gray-800">All supported genres.</p>
+        <div className="grid items-center gap-4 mt-8 grid-cols-2 mb-auto">
+          {GENRE_LIST.map((genre) => (
+            <div className="flex items-center border p-2 px-4 rounded-lg w-full duration-300" key={genre.slug}>
+              <TagText text={genre.name} />
+            </div>
+          ))}
+        </div>
+        <Footer />
+      </MainWrapper>
+    </Container>
+  );
+}


### PR DESCRIPTION
This pull request introduces a new genre listing feature to the project. The main changes include adding a genre list data structure, creating a new page to display the genres, and updating SEO metadata to support the new genre page.

Addition of genre listing feature:

* Added `GENRE_LIST` constant in `src/lib/genre-list.ts` to define supported genres with their names and slugs.
* Created a new `src/pages/genre.tsx` page that displays all genres using the `GENRE_LIST`, includes navigation and layout components, and integrates SEO metadata.

SEO updates:

* Updated `src/lib/seo/seo.ts` to add SEO metadata for the genre page, including title, description, and heading.