### PR TITLE
Potential fix for code scanning alert no. 13: Type confusion through parameter tampering

### DIFF
--- a/src/pages/api/v1/generate.ts
+++ b/src/pages/api/v1/generate.ts
@@ -57,7 +57,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const shuffle: string = req.query.shuffle as string;
   const tiktok: string = req.query.tiktok as string;
   const format: string = req.query.format as string;
-  const artist: string = req.query.artist as string;
+  const rawArtist = req.query.artist;
+  if (typeof rawArtist !== 'string') {
+    return res.status(400).json({
+      error: error.message.badRequest,
+      success: false,
+    });
+  }
+  const artist: string = rawArtist;
   const title: string = req.query.title as string;
 
   // Check if the artist field ends with ",-" which means the title wasn't provided.


### PR DESCRIPTION
Potential fix for [https://github.com/alsonick/tags.notnick.io/security/code-scanning/13](https://github.com/alsonick/tags.notnick.io/security/code-scanning/13)

The best fix is to validate `req.query.artist` at runtime and reject requests unless it is a single string. Do this right where query params are read, before any use of `artist`.

In `src/pages/api/v1/generate.ts`, replace the unsafe cast for `artist` with:
1. a raw variable from `req.query.artist`,
2. a guard `typeof rawArtist !== 'string'` returning HTTP 400,
3. then assign `artist` from the validated string value.

This preserves existing functionality for valid requests and blocks tampered array inputs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
